### PR TITLE
"Guess" Button for Input Delay Parameter

### DIFF
--- a/nullDCNetplayLauncher/Launcher.cs
+++ b/nullDCNetplayLauncher/Launcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.NetworkInformation;
 
 namespace nullDCNetplayLauncher
 {
@@ -12,6 +13,66 @@ namespace nullDCNetplayLauncher
 
         public Launcher()
         {
+        }
+
+        public static int GuessDelay(string IP)
+        {
+            int delay = -1;
+            long avgResponseTime;
+
+            List<long> responseTimes = new List<long>();
+            for (int i = 0; i < 10; i++) {
+                try
+                {
+                    Ping ping = new Ping();
+                    PingReply pingReply = ping.Send(IP, 1000);
+                    if (pingReply.Status == 0)
+                    {
+                        long responseTime = pingReply.RoundtripTime;
+                        responseTimes.Add(responseTime);
+                        Console.WriteLine(responseTime);
+                    }
+                }
+                catch (Exception err)
+                {
+                    Console.WriteLine(err.Message);
+                }
+            }
+
+            if (responseTimes.Count > 0)
+            {
+                avgResponseTime = (long)responseTimes.Average();
+
+                if (avgResponseTime < 25)
+                {
+                    delay = 1;
+                }
+                else if (avgResponseTime < 60)
+                {
+                    delay = 2;
+                }
+                else if (avgResponseTime < 100)
+                {
+                    delay = 3;
+                }
+                else if (avgResponseTime < 130)
+                {
+                    delay = 4;
+                }
+                else if (avgResponseTime < 155)
+                {
+                    delay = 5;
+                }
+                else if (avgResponseTime < 180)
+                {
+                    delay = 6;
+                }
+                else if (avgResponseTime > 180)
+                {
+                    delay = 7;
+                }
+            }
+            return delay;
         }
 
         public static void LaunchNullDC(string RomPath, bool isHost = false)

--- a/nullDCNetplayLauncher/NetplayLaunchForm.Designer.cs
+++ b/nullDCNetplayLauncher/NetplayLaunchForm.Designer.cs
@@ -43,6 +43,7 @@
             this.btnJoin = new System.Windows.Forms.Button();
             this.panel1 = new System.Windows.Forms.Panel();
             this.connectionBox = new System.Windows.Forms.GroupBox();
+            this.btnGuess = new System.Windows.Forms.Button();
             this.btnDeletePreset = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.numDelay)).BeginInit();
             this.panel1.SuspendLayout();
@@ -52,28 +53,27 @@
             // cboPresetName
             // 
             this.cboPresetName.FormattingEnabled = true;
-            this.cboPresetName.Location = new System.Drawing.Point(116, 37);
-            this.cboPresetName.Margin = new System.Windows.Forms.Padding(6);
+            this.cboPresetName.Location = new System.Drawing.Point(58, 19);
             this.cboPresetName.Name = "cboPresetName";
-            this.cboPresetName.Size = new System.Drawing.Size(262, 33);
+            this.cboPresetName.Size = new System.Drawing.Size(133, 21);
             this.cboPresetName.TabIndex = 34;
             this.cboPresetName.TextChanged += new System.EventHandler(this.cboPresetName_TextChanged);
             // 
             // txtIP
             // 
-            this.txtIP.Location = new System.Drawing.Point(194, 87);
-            this.txtIP.Margin = new System.Windows.Forms.Padding(4);
+            this.txtIP.Location = new System.Drawing.Point(97, 45);
+            this.txtIP.Margin = new System.Windows.Forms.Padding(2);
             this.txtIP.Name = "txtIP";
-            this.txtIP.Size = new System.Drawing.Size(184, 31);
+            this.txtIP.Size = new System.Drawing.Size(94, 20);
             this.txtIP.TabIndex = 27;
             this.txtIP.Text = "0.0.0.0";
             // 
             // numDelay
             // 
-            this.numDelay.Location = new System.Drawing.Point(194, 179);
-            this.numDelay.Margin = new System.Windows.Forms.Padding(4);
+            this.numDelay.Location = new System.Drawing.Point(97, 93);
+            this.numDelay.Margin = new System.Windows.Forms.Padding(2);
             this.numDelay.Name = "numDelay";
-            this.numDelay.Size = new System.Drawing.Size(188, 31);
+            this.numDelay.Size = new System.Drawing.Size(33, 20);
             this.numDelay.TabIndex = 33;
             this.numDelay.Value = new decimal(new int[] {
             1,
@@ -83,10 +83,10 @@
             // 
             // btnSavePreset
             // 
-            this.btnSavePreset.Location = new System.Drawing.Point(115, 225);
-            this.btnSavePreset.Margin = new System.Windows.Forms.Padding(4);
+            this.btnSavePreset.Location = new System.Drawing.Point(58, 117);
+            this.btnSavePreset.Margin = new System.Windows.Forms.Padding(2);
             this.btnSavePreset.Name = "btnSavePreset";
-            this.btnSavePreset.Size = new System.Drawing.Size(125, 38);
+            this.btnSavePreset.Size = new System.Drawing.Size(62, 20);
             this.btnSavePreset.TabIndex = 28;
             this.btnSavePreset.Text = "Save";
             this.btnSavePreset.UseVisualStyleBackColor = true;
@@ -95,57 +95,57 @@
             // lblDelay
             // 
             this.lblDelay.AutoSize = true;
-            this.lblDelay.Location = new System.Drawing.Point(110, 183);
-            this.lblDelay.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblDelay.Location = new System.Drawing.Point(55, 95);
+            this.lblDelay.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblDelay.Name = "lblDelay";
-            this.lblDelay.Size = new System.Drawing.Size(67, 25);
+            this.lblDelay.Size = new System.Drawing.Size(34, 13);
             this.lblDelay.TabIndex = 32;
             this.lblDelay.Text = "Delay";
             // 
             // lblPort
             // 
             this.lblPort.AutoSize = true;
-            this.lblPort.Location = new System.Drawing.Point(110, 138);
-            this.lblPort.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblPort.Location = new System.Drawing.Point(55, 72);
+            this.lblPort.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblPort.Name = "lblPort";
-            this.lblPort.Size = new System.Drawing.Size(51, 25);
+            this.lblPort.Size = new System.Drawing.Size(26, 13);
             this.lblPort.TabIndex = 31;
             this.lblPort.Text = "Port";
             // 
             // txtPort
             // 
-            this.txtPort.Location = new System.Drawing.Point(194, 133);
-            this.txtPort.Margin = new System.Windows.Forms.Padding(4);
+            this.txtPort.Location = new System.Drawing.Point(97, 69);
+            this.txtPort.Margin = new System.Windows.Forms.Padding(2);
             this.txtPort.Name = "txtPort";
-            this.txtPort.Size = new System.Drawing.Size(184, 31);
+            this.txtPort.Size = new System.Drawing.Size(94, 20);
             this.txtPort.TabIndex = 30;
             this.txtPort.Text = "27886";
             // 
             // lblIP
             // 
             this.lblIP.AutoSize = true;
-            this.lblIP.Location = new System.Drawing.Point(110, 92);
-            this.lblIP.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblIP.Location = new System.Drawing.Point(55, 48);
+            this.lblIP.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblIP.Name = "lblIP";
-            this.lblIP.Size = new System.Drawing.Size(31, 25);
+            this.lblIP.Size = new System.Drawing.Size(17, 13);
             this.lblIP.TabIndex = 29;
             this.lblIP.Text = "IP";
             // 
             // cboGameSelect
             // 
             this.cboGameSelect.FormattingEnabled = true;
-            this.cboGameSelect.Location = new System.Drawing.Point(6, 187);
-            this.cboGameSelect.Margin = new System.Windows.Forms.Padding(4);
+            this.cboGameSelect.Location = new System.Drawing.Point(3, 97);
+            this.cboGameSelect.Margin = new System.Windows.Forms.Padding(2);
             this.cboGameSelect.Name = "cboGameSelect";
-            this.cboGameSelect.Size = new System.Drawing.Size(506, 33);
+            this.cboGameSelect.Size = new System.Drawing.Size(255, 21);
             this.cboGameSelect.TabIndex = 38;
             // 
             // btnHost
             // 
-            this.btnHost.Location = new System.Drawing.Point(6, 71);
-            this.btnHost.Margin = new System.Windows.Forms.Padding(4);
+            this.btnHost.Location = new System.Drawing.Point(3, 37);
+            this.btnHost.Margin = new System.Windows.Forms.Padding(2);
             this.btnHost.Name = "btnHost";
-            this.btnHost.Size = new System.Drawing.Size(510, 50);
+            this.btnHost.Size = new System.Drawing.Size(255, 26);
             this.btnHost.TabIndex = 36;
             this.btnHost.Text = "Host Game";
             this.btnHost.UseVisualStyleBackColor = true;
@@ -153,10 +153,10 @@
             // 
             // btnOffline
             // 
-            this.btnOffline.Location = new System.Drawing.Point(6, 17);
-            this.btnOffline.Margin = new System.Windows.Forms.Padding(4);
+            this.btnOffline.Location = new System.Drawing.Point(3, 9);
+            this.btnOffline.Margin = new System.Windows.Forms.Padding(2);
             this.btnOffline.Name = "btnOffline";
-            this.btnOffline.Size = new System.Drawing.Size(510, 50);
+            this.btnOffline.Size = new System.Drawing.Size(255, 26);
             this.btnOffline.TabIndex = 35;
             this.btnOffline.Text = "Play Offline";
             this.btnOffline.UseVisualStyleBackColor = true;
@@ -164,10 +164,10 @@
             // 
             // btnJoin
             // 
-            this.btnJoin.Location = new System.Drawing.Point(6, 129);
-            this.btnJoin.Margin = new System.Windows.Forms.Padding(4);
+            this.btnJoin.Location = new System.Drawing.Point(3, 67);
+            this.btnJoin.Margin = new System.Windows.Forms.Padding(2);
             this.btnJoin.Name = "btnJoin";
-            this.btnJoin.Size = new System.Drawing.Size(510, 50);
+            this.btnJoin.Size = new System.Drawing.Size(255, 26);
             this.btnJoin.TabIndex = 37;
             this.btnJoin.Text = "Join Game";
             this.btnJoin.UseVisualStyleBackColor = true;
@@ -181,13 +181,13 @@
             this.panel1.Controls.Add(this.btnJoin);
             this.panel1.Controls.Add(this.btnHost);
             this.panel1.Location = new System.Drawing.Point(0, 0);
-            this.panel1.Margin = new System.Windows.Forms.Padding(6);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(524, 535);
+            this.panel1.Size = new System.Drawing.Size(262, 278);
             this.panel1.TabIndex = 39;
             // 
             // connectionBox
             // 
+            this.connectionBox.Controls.Add(this.btnGuess);
             this.connectionBox.Controls.Add(this.btnDeletePreset);
             this.connectionBox.Controls.Add(this.cboPresetName);
             this.connectionBox.Controls.Add(this.btnSavePreset);
@@ -197,19 +197,28 @@
             this.connectionBox.Controls.Add(this.lblIP);
             this.connectionBox.Controls.Add(this.lblPort);
             this.connectionBox.Controls.Add(this.numDelay);
-            this.connectionBox.Location = new System.Drawing.Point(6, 237);
-            this.connectionBox.Margin = new System.Windows.Forms.Padding(6);
+            this.connectionBox.Location = new System.Drawing.Point(3, 123);
             this.connectionBox.Name = "connectionBox";
-            this.connectionBox.Padding = new System.Windows.Forms.Padding(6);
-            this.connectionBox.Size = new System.Drawing.Size(508, 290);
+            this.connectionBox.Size = new System.Drawing.Size(254, 151);
             this.connectionBox.TabIndex = 40;
             this.connectionBox.TabStop = false;
             // 
+            // btnGuess
+            // 
+            this.btnGuess.Location = new System.Drawing.Point(135, 93);
+            this.btnGuess.Name = "btnGuess";
+            this.btnGuess.Size = new System.Drawing.Size(56, 20);
+            this.btnGuess.TabIndex = 36;
+            this.btnGuess.Text = "Guess";
+            this.btnGuess.UseVisualStyleBackColor = true;
+            this.btnGuess.Click += new System.EventHandler(this.btnGuess_Click);
+            // 
             // btnDeletePreset
             // 
-            this.btnDeletePreset.Location = new System.Drawing.Point(257, 227);
+            this.btnDeletePreset.Location = new System.Drawing.Point(128, 117);
+            this.btnDeletePreset.Margin = new System.Windows.Forms.Padding(2);
             this.btnDeletePreset.Name = "btnDeletePreset";
-            this.btnDeletePreset.Size = new System.Drawing.Size(125, 38);
+            this.btnDeletePreset.Size = new System.Drawing.Size(63, 20);
             this.btnDeletePreset.TabIndex = 35;
             this.btnDeletePreset.Text = "Delete";
             this.btnDeletePreset.UseVisualStyleBackColor = true;
@@ -217,14 +226,14 @@
             // 
             // NetplayLaunchForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.ClientSize = new System.Drawing.Size(520, 537);
+            this.ClientSize = new System.Drawing.Size(260, 279);
             this.Controls.Add(this.panel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4);
+            this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "NetplayLaunchForm";
             this.Text = "NullDC Netplay";
             ((System.ComponentModel.ISupportInitialize)(this.numDelay)).EndInit();
@@ -252,5 +261,6 @@
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.GroupBox connectionBox;
         private System.Windows.Forms.Button btnDeletePreset;
+        private System.Windows.Forms.Button btnGuess;
     }
 }

--- a/nullDCNetplayLauncher/NetplayLaunchForm.cs
+++ b/nullDCNetplayLauncher/NetplayLaunchForm.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -172,5 +173,19 @@ namespace nullDCNetplayLauncher
             LoadPreset(cboPresetName.Text);
         }
 
+        private void btnGuess_Click(object sender, EventArgs e)
+        {
+            long guessedDelay = Launcher.GuessDelay(txtIP.Text);
+            if (guessedDelay >= 0)
+            {
+                numDelay.BackColor = Color.White;
+                numDelay.Value = guessedDelay;
+            }
+            else
+            {
+                numDelay.BackColor = Color.Tomato;
+                numDelay.Text = "";
+            }
+        }
     }
 }


### PR DESCRIPTION
To simplify session testing before matches, users may now press a "Guess" button next to the "Delay" parameter, pinging the user 10 times and evaluating input delay according to the average of all ping response times.

![delayguess](https://user-images.githubusercontent.com/504581/81519531-77ef4100-92f6-11ea-9569-c84601275098.gif)

The criteria for evaluating input delay follows the ones set forward by the [Guilty Gear XX Online](https://web.archive.org/web/20110513094928/http://sites.google.com/site/ggxxaconline/online-play) page:

```
 < 25ms = 1 Delay Frame needed
 < 60ms = 2 Delay Frame needed
 < 100ms = 3 Delay Frame needed
 < 130ms = 4 Delay Frame needed
 < 155ms = 5 Delay Frame needed
 < 180ms = 6 Delay Frame needed
 > 180ms = Don't even bother :(
```