### PR TITLE
Command Line Options

### DIFF
--- a/nullDCNetplayLauncher/Launcher.cs
+++ b/nullDCNetplayLauncher/Launcher.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -14,7 +16,6 @@ namespace nullDCNetplayLauncher
     {
         public static string rootDir = GetDistributionRootDirectoryName() + "\\";
         public static string SelectedGame;
-
         public Launcher()
         {
         }
@@ -47,36 +48,23 @@ namespace nullDCNetplayLauncher
             {
                 avgResponseTime = (long)responseTimes.Average();
 
-                if (avgResponseTime < 25)
-                {
-                    delay = 1;
-                }
-                else if (avgResponseTime < 60)
-                {
-                    delay = 2;
-                }
-                else if (avgResponseTime < 100)
-                {
-                    delay = 3;
-                }
-                else if (avgResponseTime < 130)
-                {
-                    delay = 4;
-                }
-                else if (avgResponseTime < 155)
-                {
-                    delay = 5;
-                }
-                else if (avgResponseTime < 180)
-                {
-                    delay = 6;
-                }
-                else if (avgResponseTime > 180)
-                {
-                    delay = 7;
-                }
+                var calcDelay = Math.Ceiling((double)avgResponseTime / 32.66);
+                delay = Convert.ToInt32(calcDelay);
             }
             return delay;
+        }
+
+        public static string GetRomPathFromGameId(string gameid)
+        {
+            string RomDir = rootDir + "nulldc-1-0-4-en-win\\roms\\";
+            string GameJsonPath = rootDir + "games.json";
+
+            JArray games = JArray.Parse(File.ReadAllText(GameJsonPath));
+
+            var path = games.FirstOrDefault(x => x.Value<string>("gameid") == $"nulldc_{gameid}").Value<string>("path");
+            path = RomDir + path;
+
+            return path;
         }
 
         public static void KillAntiMicro()
@@ -107,8 +95,8 @@ namespace nullDCNetplayLauncher
         public static void LaunchNullDC(string RomPath, bool isHost = false)
         {
             string WorkDir = rootDir + "nulldc_rom_launcher\\";
-            string RomDir = rootDir + "nulldc-1-0-4-en-win\\roms\\";
-            string launchArgs = "\"" + WorkDir + "nulldc_rom_launcher.ahk" + "\" " + "\"" + RomDir + RomPath + "\"";
+            //string RomDir = rootDir + "nulldc-1-0-4-en-win\\roms\\";
+            string launchArgs = "\"" + WorkDir + "nulldc_rom_launcher.ahk" + "\" " + "\"" + Path.GetFullPath(RomPath) + "\"";
             if (isHost == true)
                 launchArgs += " host";
             Console.WriteLine("\"" + WorkDir + "AutoHotkeyU32.exe" + "\" " + launchArgs);

--- a/nullDCNetplayLauncher/NetplayLaunchForm.cs
+++ b/nullDCNetplayLauncher/NetplayLaunchForm.cs
@@ -22,8 +22,17 @@ namespace nullDCNetplayLauncher
             launcher = new Launcher();
             romDict = ScanRoms();
             presets = ConnectionPreset.ReadPresetsFile();
-            
-            string launcherCfgText = File.ReadAllText(Launcher.rootDir + "nullDCNetplayLauncher\\launcher.cfg");
+            string launcherCfgText = "";
+            try
+            {
+                launcherCfgText = File.ReadAllText(Launcher.rootDir + "nullDCNetplayLauncher\\launcher.cfg");
+            }
+            catch(System.IO.DirectoryNotFoundException e)
+            {
+                MessageBox.Show("launcher.cfg not found. Please enter a valid root directory.");
+                System.Environment.Exit(1);
+            }
+
             if (launcherCfgText.Contains("launch_antimicro=1"))
             {
                 if (Process.GetProcessesByName("antimicro").Length == 0)
@@ -159,7 +168,6 @@ namespace nullDCNetplayLauncher
         private void cboGameSelect_SelectedIndexChanged(object sender, EventArgs e)
         {
             Launcher.SelectedGame = cboGameSelect.SelectedValue.ToString();
-            Console.WriteLine(cboGameSelect.SelectedValue);
         }
     }
 }

--- a/nullDCNetplayLauncher/Program.cs
+++ b/nullDCNetplayLauncher/Program.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
 namespace nullDCNetplayLauncher
@@ -9,11 +13,195 @@ namespace nullDCNetplayLauncher
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern bool AllocConsole();
+
+        [DllImport("kernel32.dll")]
+        static extern IntPtr GetConsoleWindow();
+
+        [DllImport("user32.dll")]
+        static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+        const int SW_HIDE = 0;
+        const int SW_SHOW = 5;
+
+        public static void ShowConsoleWindow()
         {
+            var handle = GetConsoleWindow();
+
+            if (handle == IntPtr.Zero)
+            {
+                AllocConsole();
+            }
+            else
+            {
+                ShowWindow(handle, SW_SHOW);
+            }
+        }
+
+        public static void HideConsoleWindow()
+        {
+            var handle = GetConsoleWindow();
+            ShowWindow(handle, SW_HIDE);
+        }
+
+        public static void LoadInteractive()
+        {
+            HideConsoleWindow();
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new NetplayLaunchForm());
+        }
+
+        static void Main(string[] args)
+        {
+            if (args.Length > 0 && args[0].StartsWith("--"))
+            {
+                ShowConsoleWindow();
+                Dictionary<string, string> arguments = new Dictionary<string, string>();
+                bool hosting = false;
+                bool offline = false;
+                string hostCode;
+                Launcher.HostInfo hostInfo = new Launcher.HostInfo();
+                string romPath = "";
+
+                if (args.Length == 1 && args[0] == "--help")
+                {
+                    Array.Resize(ref args, args.Length + 1);
+                    args[1] = "1";
+                }
+
+                for (int index = 0; index < args.Length - 1; index += 2)
+                {
+                    string arg = args[index].Replace("--", "");
+                    if (arg == "help")
+                    {
+                        arguments[arg] = "1";
+                    } 
+                    else
+                    {
+                        arguments[arg] = args[index + 1];
+                    }
+                    
+                }
+
+                if (arguments.ContainsKey("help"))
+                {
+                    Console.WriteLine("--root-dir <distribution root directory>");
+                    Console.WriteLine("--lst-path <path to lst file>");
+                    Console.WriteLine("--gameid <game id according to games.json>");
+                    Console.WriteLine("");
+                    Console.WriteLine("--offline <0/1>");
+                    Console.WriteLine("--delay <frame delay>");
+                    Console.WriteLine("--host-code <code>");
+                    Console.WriteLine("--hosting <0/1>");
+                    Console.WriteLine("--ip <ip address>");
+                    Console.WriteLine("--port <port number>");
+                    return;
+                }
+
+                if (arguments.ContainsKey("root-dir"))
+                {
+                    Launcher.rootDir = Regex.Replace(arguments["root-dir"], @"\s+", string.Empty) + "\\";
+                }
+
+                if (!arguments.ContainsKey("offline")
+                    && !arguments.ContainsKey("ip")
+                    && !arguments.ContainsKey("host-code"))
+                {
+                    LoadInteractive();
+                    return;
+                }
+
+                
+                if (arguments.ContainsKey("lst-path"))
+                {
+                    romPath = arguments["lst-path"];
+                }
+                else if (arguments.ContainsKey("gameid"))
+                {
+                    romPath = Launcher.GetRomPathFromGameId(arguments["gameid"]);
+                }
+                else
+                {
+                    Console.WriteLine("Please enter a valid LST path (--lst-path) or Game ID (--gameid) to continue.");
+                    return;
+                }
+
+                if (arguments.ContainsKey("offline"))
+                {
+                    offline = arguments["offline"] == "1";
+                    hosting = false;
+
+                    Console.WriteLine(arguments.Keys.ToString());
+
+                    Launcher.UpdateCFGFile(
+                        netplayEnabled: !offline,
+                        isHost: hosting);
+
+                    Launcher.LaunchNullDC(
+                        RomPath: romPath,
+                        isHost: hosting);
+                }
+                else
+                {
+                    if (arguments.ContainsKey("hosting"))
+                    {
+                        hosting = arguments["hosting"] == "1";
+                    }
+
+                    if (arguments.ContainsKey("guess-ip"))
+                    {
+                        hostInfo.Delay = Launcher.GuessDelay(arguments["guess-ip"]).ToString();
+                        Console.WriteLine($"Delay is set to {hostInfo.Delay}");
+                    }
+                    else if (arguments.ContainsKey("delay"))
+                    {
+                        hostInfo.Delay = arguments["delay"];
+                    }
+                    else
+                    {
+                        Console.WriteLine("No delay entered.");
+                        return;
+                    }
+
+                    if (arguments.ContainsKey("host-code"))
+                    {
+                        hostCode = arguments["host-code"];
+                        hostInfo = Launcher.DecodeHostCode(hostCode);
+                    }
+                    else
+                    {
+                        hostInfo.IP = arguments["ip"];
+                        hostInfo.Port = arguments["port"];
+                        if (hosting)
+                        {
+                            var genHost = Launcher.GenerateHostCode(hostInfo.IP, hostInfo.Port, hostInfo.Delay);
+                            Console.WriteLine($"Generated Host Code: {genHost}");
+                        }
+                    }
+
+                    Console.WriteLine(arguments.Keys.ToString());
+
+                    Launcher.UpdateCFGFile(
+                        netplayEnabled: !offline,
+                        isHost: hosting,
+                        hostAddress: hostInfo.IP,
+                        hostPort: hostInfo.Port,
+                        frameDelay: hostInfo.Delay);
+
+                    Launcher.LaunchNullDC(
+                        RomPath: romPath,
+                        isHost: hosting);
+                }
+
+                
+            }
+            else
+            {
+                LoadInteractive();
+            }
         }
     }
 }

--- a/nullDCNetplayLauncher/nullDCNetplayLauncher.csproj
+++ b/nullDCNetplayLauncher/nullDCNetplayLauncher.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{5E28A32B-1D97-4647-B9CA-6FAE8A5A94C8}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <RootNamespace>nullDCNetplayLauncher</RootNamespace>
     <AssemblyName>nullDCNetplayLauncher</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
@@ -50,7 +50,13 @@
   <PropertyGroup>
     <ApplicationIcon>naomi.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
     </Reference>

--- a/nullDCNetplayLauncher/packages.config
+++ b/nullDCNetplayLauncher/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.DirectInput" version="4.2.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
* NullDC Netplay Launcher may now be launched using command line options. This is so the launcher may be integrated into any external emulator launchers and frontends

```
--root-dir <distribution root directory>
--lst-path <path to lst file>
--gameid <game id according to games.json>

--offline <0/1>
--delay <frame delay>
--host-code <code>
--hosting <0/1>
--ip <ip address>
--port <port number>
```

* Optimized Delay Guessing based on Guest IP