### PR TITLE
Restore Connection Presets

### DIFF
--- a/nullDCNetplayLauncher/HostControl.Designer.cs
+++ b/nullDCNetplayLauncher/HostControl.Designer.cs
@@ -44,13 +44,16 @@
             this.btnLaunchGame = new System.Windows.Forms.Button();
             this.btnCopy = new System.Windows.Forms.Button();
             this.txtHostCode = new System.Windows.Forms.TextBox();
+            this.cboPresetName = new System.Windows.Forms.ComboBox();
+            this.btnDeletePreset = new System.Windows.Forms.Button();
+            this.btnSavePreset = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.numDelay)).BeginInit();
             this.grpCodeLaunch.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnGuess
             // 
-            this.btnGuess.Location = new System.Drawing.Point(171, 98);
+            this.btnGuess.Location = new System.Drawing.Point(171, 125);
             this.btnGuess.Margin = new System.Windows.Forms.Padding(4);
             this.btnGuess.Name = "btnGuess";
             this.btnGuess.Size = new System.Drawing.Size(75, 25);
@@ -61,7 +64,7 @@
             // 
             // txtHostPort
             // 
-            this.txtHostPort.Location = new System.Drawing.Point(120, 41);
+            this.txtHostPort.Location = new System.Drawing.Point(120, 68);
             this.txtHostPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtHostPort.Name = "txtHostPort";
             this.txtHostPort.Size = new System.Drawing.Size(124, 22);
@@ -71,7 +74,7 @@
             // lblDelay
             // 
             this.lblDelay.AutoSize = true;
-            this.lblDelay.Location = new System.Drawing.Point(44, 102);
+            this.lblDelay.Location = new System.Drawing.Point(44, 129);
             this.lblDelay.Name = "lblDelay";
             this.lblDelay.Size = new System.Drawing.Size(44, 17);
             this.lblDelay.TabIndex = 42;
@@ -79,17 +82,16 @@
             // 
             // txtGuestIP
             // 
-            this.txtGuestIP.Location = new System.Drawing.Point(120, 69);
+            this.txtGuestIP.Location = new System.Drawing.Point(120, 96);
             this.txtGuestIP.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtGuestIP.Name = "txtGuestIP";
             this.txtGuestIP.Size = new System.Drawing.Size(124, 22);
             this.txtGuestIP.TabIndex = 3;
-            this.txtGuestIP.Text = "0.0.0.0";
             // 
             // lblHostPort
             // 
             this.lblHostPort.AutoSize = true;
-            this.lblHostPort.Location = new System.Drawing.Point(44, 44);
+            this.lblHostPort.Location = new System.Drawing.Point(44, 71);
             this.lblHostPort.Name = "lblHostPort";
             this.lblHostPort.Size = new System.Drawing.Size(67, 17);
             this.lblHostPort.TabIndex = 39;
@@ -98,7 +100,7 @@
             // lblGuestIP
             // 
             this.lblGuestIP.AutoSize = true;
-            this.lblGuestIP.Location = new System.Drawing.Point(44, 74);
+            this.lblGuestIP.Location = new System.Drawing.Point(44, 101);
             this.lblGuestIP.Name = "lblGuestIP";
             this.lblGuestIP.Size = new System.Drawing.Size(62, 17);
             this.lblGuestIP.TabIndex = 41;
@@ -106,7 +108,7 @@
             // 
             // numDelay
             // 
-            this.numDelay.Location = new System.Drawing.Point(120, 98);
+            this.numDelay.Location = new System.Drawing.Point(120, 125);
             this.numDelay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.numDelay.Name = "numDelay";
             this.numDelay.Size = new System.Drawing.Size(44, 22);
@@ -116,10 +118,11 @@
             0,
             0,
             0});
+            this.numDelay.GotFocus += new System.EventHandler(this.numDelay_GotFocus);
             // 
             // txtHostIP
             // 
-            this.txtHostIP.Location = new System.Drawing.Point(120, 13);
+            this.txtHostIP.Location = new System.Drawing.Point(120, 40);
             this.txtHostIP.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtHostIP.Name = "txtHostIP";
             this.txtHostIP.Size = new System.Drawing.Size(124, 22);
@@ -129,7 +132,7 @@
             // lblHostIP
             // 
             this.lblHostIP.AutoSize = true;
-            this.lblHostIP.Location = new System.Drawing.Point(44, 16);
+            this.lblHostIP.Location = new System.Drawing.Point(44, 43);
             this.lblHostIP.Name = "lblHostIP";
             this.lblHostIP.Size = new System.Drawing.Size(53, 17);
             this.lblHostIP.TabIndex = 48;
@@ -137,7 +140,7 @@
             // 
             // btnGenHostCode
             // 
-            this.btnGenHostCode.Location = new System.Drawing.Point(10, 131);
+            this.btnGenHostCode.Location = new System.Drawing.Point(10, 158);
             this.btnGenHostCode.Name = "btnGenHostCode";
             this.btnGenHostCode.Size = new System.Drawing.Size(273, 23);
             this.btnGenHostCode.TabIndex = 6;
@@ -151,7 +154,7 @@
             this.grpCodeLaunch.Controls.Add(this.btnLaunchGame);
             this.grpCodeLaunch.Controls.Add(this.btnCopy);
             this.grpCodeLaunch.Controls.Add(this.txtHostCode);
-            this.grpCodeLaunch.Location = new System.Drawing.Point(5, 160);
+            this.grpCodeLaunch.Location = new System.Drawing.Point(5, 187);
             this.grpCodeLaunch.Name = "grpCodeLaunch";
             this.grpCodeLaunch.Size = new System.Drawing.Size(280, 104);
             this.grpCodeLaunch.TabIndex = 50;
@@ -195,11 +198,46 @@
             this.txtHostCode.Name = "txtHostCode";
             this.txtHostCode.Size = new System.Drawing.Size(235, 22);
             this.txtHostCode.TabIndex = 7;
+            this.txtHostCode.GotFocus += new System.EventHandler(this.txtHostCode_GotFocus);
+            // 
+            // cboPresetName
+            // 
+            this.cboPresetName.FormattingEnabled = true;
+            this.cboPresetName.Location = new System.Drawing.Point(47, 6);
+            this.cboPresetName.Name = "cboPresetName";
+            this.cboPresetName.Size = new System.Drawing.Size(135, 24);
+            this.cboPresetName.TabIndex = 1;
+            this.cboPresetName.SelectedIndexChanged += new System.EventHandler(this.cboPresetName_SelectedIndexChanged);
+            this.cboPresetName.GotFocus += new System.EventHandler(this.cboPresetName_GotFocus);
+
+            // 
+            // btnDeletePreset
+            // 
+            this.btnDeletePreset.Image = ((System.Drawing.Image)(resources.GetObject("btnDeletePreset.Image")));
+            this.btnDeletePreset.Location = new System.Drawing.Point(184, 4);
+            this.btnDeletePreset.Name = "btnDeletePreset";
+            this.btnDeletePreset.Size = new System.Drawing.Size(30, 27);
+            this.btnDeletePreset.TabIndex = 2;
+            this.btnDeletePreset.UseVisualStyleBackColor = true;
+            this.btnDeletePreset.Click += new System.EventHandler(this.btnDeletePreset_Click);
+            // 
+            // btnSavePreset
+            // 
+            this.btnSavePreset.Image = ((System.Drawing.Image)(resources.GetObject("btnSavePreset.Image")));
+            this.btnSavePreset.Location = new System.Drawing.Point(214, 4);
+            this.btnSavePreset.Name = "btnSavePreset";
+            this.btnSavePreset.Size = new System.Drawing.Size(30, 27);
+            this.btnSavePreset.TabIndex = 3;
+            this.btnSavePreset.UseVisualStyleBackColor = true;
+            this.btnSavePreset.Click += new System.EventHandler(this.btnSavePreset_Click);
             // 
             // HostControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.btnSavePreset);
+            this.Controls.Add(this.btnDeletePreset);
+            this.Controls.Add(this.cboPresetName);
             this.Controls.Add(this.grpCodeLaunch);
             this.Controls.Add(this.btnGenHostCode);
             this.Controls.Add(this.txtHostIP);
@@ -212,7 +250,7 @@
             this.Controls.Add(this.lblGuestIP);
             this.Controls.Add(this.numDelay);
             this.Name = "HostControl";
-            this.Size = new System.Drawing.Size(290, 271);
+            this.Size = new System.Drawing.Size(290, 297);
             ((System.ComponentModel.ISupportInitialize)(this.numDelay)).EndInit();
             this.grpCodeLaunch.ResumeLayout(false);
             this.grpCodeLaunch.PerformLayout();
@@ -238,5 +276,8 @@
         private System.Windows.Forms.Button btnLaunchGame;
         private System.Windows.Forms.Button btnCopy;
         private System.Windows.Forms.TextBox txtHostCode;
+        private System.Windows.Forms.ComboBox cboPresetName;
+        private System.Windows.Forms.Button btnDeletePreset;
+        private System.Windows.Forms.Button btnSavePreset;
     }
 }

--- a/nullDCNetplayLauncher/HostControl.resx
+++ b/nullDCNetplayLauncher/HostControl.resx
@@ -127,4 +127,21 @@
         AZUG69nGtx0DAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="btnDeletePreset.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        xAAADsQBlSsOGwAAALFJREFUOE+tkDESwiAQRbmA17C2tKb2EBbeICfKEeQGXkZNFWho1/wdlsEMgXVM
+        8cJC9r9ZMET0F/yJMZ6AHK73LaTZJzhY7muhEgj8Y7gRQO3fz3C/nPO+JzFhehEC4/HAIamxqgRLw7WU
+        SBiT9MKA30DGFoF2fGDKMFap1W8gAoBarpMEXfIVAOoFfhPnHFlrm7AAY6RgHhU/0ODnsMmXYM1ugh5N
+        gZaq4Beqh3rIfADNkAPZUpn57QAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="btnSavePreset.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        xAAADsQBlSsOGwAAAHhJREFUOE9j+PbtWzgQvwHi/yRikJ5wkAFvtAvW/GcInkMSBukB6QUZgFUBMRis
+        F9mAD+8/EoWHswGk4kFqADY/I2NktbQ1AJ2PLg7CMAPuFM8/hqEBnY8uDsIwA2SQDUFXiKwZWRyEwQaA
+        AMwQkABIEYgmDn/7DwBpTOrUXkrGYgAAAABJRU5ErkJggg==
+</value>
+  </data>
 </root>

--- a/nullDCNetplayLauncher/JoinControl.Designer.cs
+++ b/nullDCNetplayLauncher/JoinControl.Designer.cs
@@ -29,34 +29,131 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(JoinControl));
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.btnGuess = new System.Windows.Forms.Button();
+            this.txtHostPort = new System.Windows.Forms.TextBox();
+            this.lblDelay = new System.Windows.Forms.Label();
+            this.txtGuestIP = new System.Windows.Forms.TextBox();
+            this.lblHostPort = new System.Windows.Forms.Label();
+            this.lblGuestIP = new System.Windows.Forms.Label();
+            this.numDelay = new System.Windows.Forms.NumericUpDown();
+            this.txtHostIP = new System.Windows.Forms.TextBox();
+            this.lblHostIP = new System.Windows.Forms.Label();
+            this.grpCodeLaunch = new System.Windows.Forms.GroupBox();
             this.label1 = new System.Windows.Forms.Label();
             this.btnLaunchGame = new System.Windows.Forms.Button();
             this.btnPaste = new System.Windows.Forms.Button();
             this.txtHostCode = new System.Windows.Forms.TextBox();
-            this.groupBox1.SuspendLayout();
+            this.btnSavePreset = new System.Windows.Forms.Button();
+            this.btnDeletePreset = new System.Windows.Forms.Button();
+            this.cboPresetName = new System.Windows.Forms.ComboBox();
+            ((System.ComponentModel.ISupportInitialize)(this.numDelay)).BeginInit();
+            this.grpCodeLaunch.SuspendLayout();
             this.SuspendLayout();
             // 
-            // groupBox1
+            // btnGuess
             // 
-            this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Controls.Add(this.btnLaunchGame);
-            this.groupBox1.Controls.Add(this.btnPaste);
-            this.groupBox1.Controls.Add(this.txtHostCode);
-            this.groupBox1.Location = new System.Drawing.Point(4, 4);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(280, 104);
-            this.groupBox1.TabIndex = 52;
-            this.groupBox1.TabStop = false;
+            this.btnGuess.Location = new System.Drawing.Point(171, 233);
+            this.btnGuess.Margin = new System.Windows.Forms.Padding(4);
+            this.btnGuess.Name = "btnGuess";
+            this.btnGuess.Size = new System.Drawing.Size(75, 25);
+            this.btnGuess.TabIndex = 5;
+            this.btnGuess.Text = "Guess";
+            this.btnGuess.UseVisualStyleBackColor = true;
+            this.btnGuess.Click += new System.EventHandler(this.btnGuess_Click);
+            // 
+            // txtHostPort
+            // 
+            this.txtHostPort.Location = new System.Drawing.Point(120, 176);
+            this.txtHostPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.txtHostPort.Name = "txtHostPort";
+            this.txtHostPort.Size = new System.Drawing.Size(124, 22);
+            this.txtHostPort.TabIndex = 2;
+            // 
+            // lblDelay
+            // 
+            this.lblDelay.AutoSize = true;
+            this.lblDelay.Location = new System.Drawing.Point(44, 237);
+            this.lblDelay.Name = "lblDelay";
+            this.lblDelay.Size = new System.Drawing.Size(44, 17);
+            this.lblDelay.TabIndex = 42;
+            this.lblDelay.Text = "Delay";
+            // 
+            // txtGuestIP
+            // 
+            this.txtGuestIP.Location = new System.Drawing.Point(120, 204);
+            this.txtGuestIP.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.txtGuestIP.Name = "txtGuestIP";
+            this.txtGuestIP.Size = new System.Drawing.Size(124, 22);
+            this.txtGuestIP.TabIndex = 3;
+            // 
+            // lblHostPort
+            // 
+            this.lblHostPort.AutoSize = true;
+            this.lblHostPort.Location = new System.Drawing.Point(44, 179);
+            this.lblHostPort.Name = "lblHostPort";
+            this.lblHostPort.Size = new System.Drawing.Size(67, 17);
+            this.lblHostPort.TabIndex = 39;
+            this.lblHostPort.Text = "Host Port";
+            // 
+            // lblGuestIP
+            // 
+            this.lblGuestIP.AutoSize = true;
+            this.lblGuestIP.Location = new System.Drawing.Point(44, 209);
+            this.lblGuestIP.Name = "lblGuestIP";
+            this.lblGuestIP.Size = new System.Drawing.Size(62, 17);
+            this.lblGuestIP.TabIndex = 41;
+            this.lblGuestIP.Text = "Guest IP";
+            // 
+            // numDelay
+            // 
+            this.numDelay.Location = new System.Drawing.Point(120, 233);
+            this.numDelay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.numDelay.Name = "numDelay";
+            this.numDelay.Size = new System.Drawing.Size(44, 22);
+            this.numDelay.TabIndex = 4;
+            this.numDelay.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            // 
+            // txtHostIP
+            // 
+            this.txtHostIP.Location = new System.Drawing.Point(120, 148);
+            this.txtHostIP.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.txtHostIP.Name = "txtHostIP";
+            this.txtHostIP.Size = new System.Drawing.Size(124, 22);
+            this.txtHostIP.TabIndex = 1;
+            // 
+            // lblHostIP
+            // 
+            this.lblHostIP.AutoSize = true;
+            this.lblHostIP.Location = new System.Drawing.Point(44, 151);
+            this.lblHostIP.Name = "lblHostIP";
+            this.lblHostIP.Size = new System.Drawing.Size(53, 17);
+            this.lblHostIP.TabIndex = 48;
+            this.lblHostIP.Text = "Host IP";
+            // 
+            // grpCodeLaunch
+            // 
+            this.grpCodeLaunch.Controls.Add(this.label1);
+            this.grpCodeLaunch.Controls.Add(this.btnLaunchGame);
+            this.grpCodeLaunch.Controls.Add(this.btnPaste);
+            this.grpCodeLaunch.Controls.Add(this.txtHostCode);
+            this.grpCodeLaunch.Location = new System.Drawing.Point(5, 3);
+            this.grpCodeLaunch.Name = "grpCodeLaunch";
+            this.grpCodeLaunch.Size = new System.Drawing.Size(280, 104);
+            this.grpCodeLaunch.TabIndex = 50;
+            this.grpCodeLaunch.TabStop = false;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(84, 18);
+            this.label1.Location = new System.Drawing.Point(103, 18);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(112, 17);
+            this.label1.Size = new System.Drawing.Size(74, 17);
             this.label1.TabIndex = 51;
-            this.label1.Text = "Enter Host Code";
+            this.label1.Text = "Host Code";
             this.label1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // btnLaunchGame
@@ -64,7 +161,7 @@
             this.btnLaunchGame.Location = new System.Drawing.Point(6, 66);
             this.btnLaunchGame.Name = "btnLaunchGame";
             this.btnLaunchGame.Size = new System.Drawing.Size(268, 23);
-            this.btnLaunchGame.TabIndex = 3;
+            this.btnLaunchGame.TabIndex = 9;
             this.btnLaunchGame.Text = "Launch Game";
             this.btnLaunchGame.UseVisualStyleBackColor = true;
             this.btnLaunchGame.Click += new System.EventHandler(this.btnLaunchGame_Click);
@@ -77,7 +174,7 @@
             this.btnPaste.Location = new System.Drawing.Point(247, 38);
             this.btnPaste.Name = "btnPaste";
             this.btnPaste.Size = new System.Drawing.Size(27, 22);
-            this.btnPaste.TabIndex = 2;
+            this.btnPaste.TabIndex = 8;
             this.btnPaste.UseVisualStyleBackColor = true;
             this.btnPaste.Click += new System.EventHandler(this.btnPaste_Click);
             // 
@@ -86,27 +183,85 @@
             this.txtHostCode.Location = new System.Drawing.Point(6, 38);
             this.txtHostCode.Name = "txtHostCode";
             this.txtHostCode.Size = new System.Drawing.Size(235, 22);
-            this.txtHostCode.TabIndex = 1;
+            this.txtHostCode.TabIndex = 7;
+            this.txtHostCode.TextChanged += new System.EventHandler(this.txtHostCode_TextChanged);
+            this.txtHostCode.GotFocus += new System.EventHandler(this.txtHostCode_GotFocus);
+            // 
+            // btnSavePreset
+            // 
+            this.btnSavePreset.Image = ((System.Drawing.Image)(resources.GetObject("btnSavePreset.Image")));
+            this.btnSavePreset.Location = new System.Drawing.Point(214, 111);
+            this.btnSavePreset.Name = "btnSavePreset";
+            this.btnSavePreset.Size = new System.Drawing.Size(30, 27);
+            this.btnSavePreset.TabIndex = 53;
+            this.btnSavePreset.UseVisualStyleBackColor = true;
+            this.btnSavePreset.Click += new System.EventHandler(this.btnSavePreset_Click);
+            // 
+            // btnDeletePreset
+            // 
+            this.btnDeletePreset.Image = ((System.Drawing.Image)(resources.GetObject("btnDeletePreset.Image")));
+            this.btnDeletePreset.Location = new System.Drawing.Point(184, 111);
+            this.btnDeletePreset.Name = "btnDeletePreset";
+            this.btnDeletePreset.Size = new System.Drawing.Size(30, 27);
+            this.btnDeletePreset.TabIndex = 52;
+            this.btnDeletePreset.UseVisualStyleBackColor = true;
+            this.btnDeletePreset.Click += new System.EventHandler(this.btnDeletePreset_Click);
+            // 
+            // cboPresetName
+            // 
+            this.cboPresetName.FormattingEnabled = true;
+            this.cboPresetName.Location = new System.Drawing.Point(47, 113);
+            this.cboPresetName.Name = "cboPresetName";
+            this.cboPresetName.Size = new System.Drawing.Size(135, 24);
+            this.cboPresetName.TabIndex = 51;
+            this.cboPresetName.SelectedIndexChanged += new System.EventHandler(this.cboPresetName_SelectedIndexChanged);
+            this.cboPresetName.TextChanged += new System.EventHandler(this.cboPresetName_TextChanged);
             // 
             // JoinControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.btnSavePreset);
+            this.Controls.Add(this.btnDeletePreset);
+            this.Controls.Add(this.cboPresetName);
+            this.Controls.Add(this.grpCodeLaunch);
+            this.Controls.Add(this.txtHostIP);
+            this.Controls.Add(this.lblHostIP);
+            this.Controls.Add(this.btnGuess);
+            this.Controls.Add(this.txtHostPort);
+            this.Controls.Add(this.lblDelay);
+            this.Controls.Add(this.txtGuestIP);
+            this.Controls.Add(this.lblHostPort);
+            this.Controls.Add(this.lblGuestIP);
+            this.Controls.Add(this.numDelay);
             this.Name = "JoinControl";
-            this.Size = new System.Drawing.Size(288, 112);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
+            this.Size = new System.Drawing.Size(290, 275);
+            ((System.ComponentModel.ISupportInitialize)(this.numDelay)).EndInit();
+            this.grpCodeLaunch.ResumeLayout(false);
+            this.grpCodeLaunch.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
 
-        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.Button btnGuess;
+        private System.Windows.Forms.TextBox txtHostPort;
+        private System.Windows.Forms.Label lblDelay;
+        private System.Windows.Forms.TextBox txtGuestIP;
+        private System.Windows.Forms.Label lblHostPort;
+        private System.Windows.Forms.Label lblGuestIP;
+        private System.Windows.Forms.NumericUpDown numDelay;
+        private System.Windows.Forms.TextBox txtHostIP;
+        private System.Windows.Forms.Label lblHostIP;
+        private System.Windows.Forms.GroupBox grpCodeLaunch;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnLaunchGame;
         private System.Windows.Forms.Button btnPaste;
         private System.Windows.Forms.TextBox txtHostCode;
+        private System.Windows.Forms.Button btnSavePreset;
+        private System.Windows.Forms.Button btnDeletePreset;
+        private System.Windows.Forms.ComboBox cboPresetName;
     }
 }

--- a/nullDCNetplayLauncher/JoinControl.cs
+++ b/nullDCNetplayLauncher/JoinControl.cs
@@ -7,32 +7,193 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.Text.RegularExpressions;
+using System.IO;
 
 namespace nullDCNetplayLauncher
 {
     public partial class JoinControl : UserControl
     {
+        ConnectionPresetList presets;
+
         public JoinControl()
         {
+            presets = ConnectionPreset.ReadPresetsFile();
             InitializeComponent();
+
+            cboPresetName.DataSource = presets.ConnectionPresets;
+
+            btnDeletePreset.Enabled = presets.ConnectionPresets.Count > 1;
+        }
+
+        private void btnGuess_Click(object sender, EventArgs e)
+        {
+            long guessedDelay = Launcher.GuessDelay(txtGuestIP.Text);
+            if (guessedDelay >= 0)
+            {
+                numDelay.BackColor = Color.White;
+                numDelay.Value = guessedDelay;
+            }
+            else
+            {
+                numDelay.BackColor = Color.Tomato;
+                numDelay.Text = "";
+            }
         }
 
         private void btnLaunchGame_Click(object sender, EventArgs e)
         {
-            Launcher.HostInfo decodedHostInfo = Launcher.DecodeHostCode(txtHostCode.Text);
             Launcher.UpdateCFGFile(
                 netplayEnabled: true,
-                isHost: false,
-                hostAddress: decodedHostInfo.IP,
-                hostPort: decodedHostInfo.Port,
-                frameDelay: decodedHostInfo.Delay);
-            Launcher.LaunchNullDC(Launcher.SelectedGame);
+                isHost: true,
+                hostAddress: txtHostIP.Text,
+                hostPort: txtHostPort.Text,
+                frameDelay: Convert.ToInt32(numDelay.Value)
+                                   .ToString());
+            Launcher.LaunchNullDC(Launcher.SelectedGame, isHost: true);
         }
 
         private void btnPaste_Click(object sender, EventArgs e)
         {
+            txtHostCode.BackColor = Color.LemonChiffon;
             txtHostCode.Text = Clipboard.GetText();
-            MessageBox.Show("Host Code Pasted from Clipboard");
+        }
+
+        private void txtHostCode_GotFocus(object sender, EventArgs e)
+        {
+            txtHostCode.BackColor = Color.White;
+        }
+
+        private void txtHostPort_GotFocus(object sender, EventArgs e)
+        {
+            txtHostPort.BackColor = Color.White;
+        }
+
+        private void numDelay_GotFocus(object sender, EventArgs e)
+        {
+            txtHostCode.BackColor = Color.White;
+        }
+
+        private void cboPresetName_GotFocus(object sender, EventArgs e)
+        {
+            cboPresetName.BackColor = Color.White;
+        }
+
+        private void txtHostCode_TextChanged(object sender, EventArgs e)
+        {
+            string base64Pattern = @"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9 +/]{3}=)?$";
+            bool isBase64 = Regex.IsMatch(txtHostCode.Text, base64Pattern);
+            if (isBase64 || txtHostCode.Text == "")
+            {
+                var hostInfo = Launcher.DecodeHostCode(txtHostCode.Text);
+
+                if (!String.IsNullOrEmpty(hostInfo.Port))
+                {
+                    cboPresetName.Text = "";
+
+                    txtHostIP.BackColor = Color.LemonChiffon;
+                    txtHostPort.BackColor = Color.LemonChiffon;
+                    numDelay.BackColor = Color.LemonChiffon;
+
+                    txtHostIP.Text = hostInfo.IP;
+                    txtHostPort.Text = hostInfo.Port;
+                    numDelay.Value = Convert.ToInt32(hostInfo.Delay);
+                }
+            }
+        }
+
+        public void SavePreset(string presetName)
+        {
+            var toEdit = presets.ConnectionPresets.FirstOrDefault(p => p.Name == presetName);
+            if (toEdit != null)
+            {
+                toEdit.IP = txtHostIP.Text;
+                toEdit.Port = txtHostPort.Text;
+                toEdit.Delay = numDelay.Value;
+            }
+            else
+            {
+                var toAdd = new ConnectionPreset();
+                toAdd.Name = cboPresetName.Text;
+                toAdd.IP = txtHostIP.Text;
+                toAdd.Port = txtHostPort.Text;
+                toAdd.Delay = numDelay.Value;
+                presets.ConnectionPresets.Add(toAdd);
+            }
+
+            var path = Launcher.GetApplicationConfigurationDirectoryName() + "//ConnectionPresetList.xml";
+            System.Xml.Serialization.XmlSerializer serializer =
+                new System.Xml.Serialization.XmlSerializer(typeof(ConnectionPresetList));
+            StreamWriter writer = new StreamWriter(path);
+            serializer.Serialize(writer.BaseStream, presets);
+            writer.Close();
+            presets = ConnectionPreset.ReadPresetsFile();
+            cboPresetName.DataSource = presets.ConnectionPresets;
+            cboPresetName.SelectedIndex = cboPresetName.FindStringExact(presetName);
+            if (presets.ConnectionPresets.Count > 1)
+            {
+                btnDeletePreset.Enabled = true;
+            }
+            cboPresetName.BackColor = Color.LemonChiffon;
+        }
+
+        public void DeletePreset(string presetName)
+        {
+            if (presets.ConnectionPresets.Count > 1)
+            {
+                var toDelete = presets.ConnectionPresets.FirstOrDefault(p => p.Name == presetName);
+                presets.ConnectionPresets.Remove(toDelete);
+
+                var path = Launcher.GetApplicationConfigurationDirectoryName() + "//ConnectionPresetList.xml";
+                System.Xml.Serialization.XmlSerializer serializer =
+                    new System.Xml.Serialization.XmlSerializer(typeof(ConnectionPresetList));
+                StreamWriter writer = new StreamWriter(path);
+                serializer.Serialize(writer.BaseStream, presets);
+                writer.Close();
+                presets = ConnectionPreset.ReadPresetsFile();
+                cboPresetName.DataSource = presets.ConnectionPresets;
+                cboPresetName.SelectedIndex = 0;
+                if (presets.ConnectionPresets.Count == 1)
+                {
+                    btnDeletePreset.Enabled = false;
+                }
+            }
+        }
+
+        private void LoadPreset(string presetName)
+        {
+            ConnectionPreset toLoad = presets.ConnectionPresets.FirstOrDefault(p => p.Name == presetName);
+            if (toLoad != null)
+            {
+                txtHostIP.Text = toLoad.IP;
+                txtHostPort.Text = toLoad.Port;
+                numDelay.Value = toLoad.Delay;
+            }
+        }
+
+        private void btnSavePreset_Click(object sender, EventArgs e)
+        {
+            SavePreset(cboPresetName.Text);
+        }
+
+        private void btnDeletePreset_Click(object sender, EventArgs e)
+        {
+            DeletePreset(cboPresetName.Text);
+        }
+
+        private void cboPresetName_TextChanged(object sender, EventArgs e)
+        {
+            LoadPreset(cboPresetName.Text);
+        }
+
+        private void cboPresetName_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            cboPresetName.BackColor = Color.White;
+            txtHostCode.BackColor = Color.White;
+            txtHostIP.BackColor = Color.White;
+            txtHostPort.BackColor = Color.White;
+            numDelay.BackColor = Color.White;
+            LoadPreset(cboPresetName.Text);
         }
 
     }

--- a/nullDCNetplayLauncher/JoinControl.resx
+++ b/nullDCNetplayLauncher/JoinControl.resx
@@ -127,4 +127,21 @@
         AZUG69nGtx0DAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="btnSavePreset.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        xAAADsQBlSsOGwAAAHhJREFUOE9j+PbtWzgQvwHi/yRikJ5wkAFvtAvW/GcInkMSBukB6QUZgFUBMRis
+        F9mAD+8/EoWHswGk4kFqADY/I2NktbQ1AJ2PLg7CMAPuFM8/hqEBnY8uDsIwA2SQDUFXiKwZWRyEwQaA
+        AMwQkABIEYgmDn/7DwBpTOrUXkrGYgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="btnDeletePreset.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        xAAADsQBlSsOGwAAALFJREFUOE+tkDESwiAQRbmA17C2tKb2EBbeICfKEeQGXkZNFWho1/wdlsEMgXVM
+        8cJC9r9ZMET0F/yJMZ6AHK73LaTZJzhY7muhEgj8Y7gRQO3fz3C/nPO+JzFhehEC4/HAIamxqgRLw7WU
+        SBiT9MKA30DGFoF2fGDKMFap1W8gAoBarpMEXfIVAOoFfhPnHFlrm7AAY6RgHhU/0ODnsMmXYM1ugh5N
+        gZaq4Beqh3rIfADNkAPZUpn57QAAAABJRU5ErkJggg==
+</value>
+  </data>
 </root>

--- a/nullDCNetplayLauncher/Launcher.cs
+++ b/nullDCNetplayLauncher/Launcher.cs
@@ -187,9 +187,12 @@ namespace nullDCNetplayLauncher
             var infoString = System.Text.Encoding.UTF8.GetString(encodedInfoBytes);
             var hostInfoArray = infoString.Split('|');
             HostInfo decodedHostInfo = new HostInfo();
-            decodedHostInfo.IP = hostInfoArray[0];
-            decodedHostInfo.Port = hostInfoArray[1];
-            decodedHostInfo.Delay = hostInfoArray[2];
+            if (hostInfoArray.Length == 3)
+            {
+                decodedHostInfo.IP = hostInfoArray[0];
+                decodedHostInfo.Port = hostInfoArray[1];
+                decodedHostInfo.Delay = hostInfoArray[2];
+            }
             return decodedHostInfo;
         }
 

--- a/nullDCNetplayLauncher/Launcher.cs
+++ b/nullDCNetplayLauncher/Launcher.cs
@@ -164,7 +164,7 @@ namespace nullDCNetplayLauncher
         public static string ExtractRelativeRomPath(string path)
         {
             List<string> splitPath = path.Split(Path.DirectorySeparatorChar).ToList();
-            return String.Join("\\", Enumerable.Reverse(splitPath).Take(2).Reverse().ToList<string>());
+            return String.Join("\\", Enumerable.Reverse(splitPath).Take(4).Reverse().ToList<string>());
         }
 
         public static string GenerateHostCode(string ip, string port, string delay)
@@ -213,8 +213,6 @@ namespace nullDCNetplayLauncher
             public int Right { get; set; }
             public int Bottom { get; set; }
         }
-
-
 
         public static IntPtr NullDCWindowHandle()
         {

--- a/nullDCNetplayLauncher/Program.cs
+++ b/nullDCNetplayLauncher/Program.cs
@@ -54,6 +54,7 @@ namespace nullDCNetplayLauncher
             Application.Run(new NetplayLaunchForm());
         }
 
+        [STAThread]
         static void Main(string[] args)
         {
             if (args.Length > 0 && args[0].StartsWith("--"))

--- a/nullDCNetplayLauncher/nullDCNetplayLauncher.csproj
+++ b/nullDCNetplayLauncher/nullDCNetplayLauncher.csproj
@@ -83,6 +83,12 @@
     <Compile Include="ControllerControl.Designer.cs">
       <DependentUpon>ControllerControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="JoinControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="JoinControl.Designer.cs">
+      <DependentUpon>JoinControl.cs</DependentUpon>
+    </Compile>
     <Compile Include="HostControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -105,14 +111,11 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="JoinControl.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Include="JoinControl.Designer.cs">
-      <DependentUpon>JoinControl.cs</DependentUpon>
-    </Compile>
     <EmbeddedResource Include="ControllerControl.resx">
       <DependentUpon>ControllerControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="JoinControl.resx">
+      <DependentUpon>JoinControl.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="HostControl.resx">
       <DependentUpon>HostControl.cs</DependentUpon>
@@ -132,9 +135,6 @@
     </Compile>
     <EmbeddedResource Include="SettingsControl.resx">
       <DependentUpon>SettingsControl.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="JoinControl.resx">
-      <DependentUpon>JoinControl.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">


### PR DESCRIPTION
* Saves/Loads Connection Presets (again)
* Allows hosts & guests to choose between host codes & fill server details for connections.

![host_presets](https://user-images.githubusercontent.com/504581/83958211-1a321400-a824-11ea-8be2-d4440a9a4379.gif)

![guest_presets](https://user-images.githubusercontent.com/504581/83958213-1f8f5e80-a824-11ea-9221-ad4a32d6964a.gif)

