### PR TITLE
Netplay Method Selection / Backwards Compatibility

### DIFF
--- a/nullDCNetplayLauncher/ConnectionPreset.cs
+++ b/nullDCNetplayLauncher/ConnectionPreset.cs
@@ -15,6 +15,7 @@ namespace nullDCNetplayLauncher
         public string IP;
         public string Port;
         public decimal Delay;
+        public int Method;
 
         public override string ToString()
         {
@@ -38,9 +39,10 @@ namespace nullDCNetplayLauncher
             {
                 ConnectionPreset defaultPreset = new ConnectionPreset();
                 defaultPreset.Name = "Default";
-                defaultPreset.IP = "0.0.0.0";
+                defaultPreset.IP = "127.0.0.1";
                 defaultPreset.Port = "27886";
                 defaultPreset.Delay = 1;
+                defaultPreset.Method = 0;
                 readPresetList = new ConnectionPresetList();
                 readPresetList.ConnectionPresets.Add(defaultPreset);
             }

--- a/nullDCNetplayLauncher/HostControl.Designer.cs
+++ b/nullDCNetplayLauncher/HostControl.Designer.cs
@@ -47,16 +47,18 @@
             this.cboPresetName = new System.Windows.Forms.ComboBox();
             this.btnDeletePreset = new System.Windows.Forms.Button();
             this.btnSavePreset = new System.Windows.Forms.Button();
+            this.cboMethod = new System.Windows.Forms.ComboBox();
+            this.lblMethod = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.numDelay)).BeginInit();
             this.grpCodeLaunch.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnGuess
             // 
-            this.btnGuess.Location = new System.Drawing.Point(171, 125);
+            this.btnGuess.Location = new System.Drawing.Point(169, 116);
             this.btnGuess.Margin = new System.Windows.Forms.Padding(4);
             this.btnGuess.Name = "btnGuess";
-            this.btnGuess.Size = new System.Drawing.Size(75, 25);
+            this.btnGuess.Size = new System.Drawing.Size(77, 25);
             this.btnGuess.TabIndex = 5;
             this.btnGuess.Text = "Guess";
             this.btnGuess.UseVisualStyleBackColor = true;
@@ -64,17 +66,17 @@
             // 
             // txtHostPort
             // 
-            this.txtHostPort.Location = new System.Drawing.Point(120, 68);
+            this.txtHostPort.Location = new System.Drawing.Point(120, 66);
             this.txtHostPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtHostPort.Name = "txtHostPort";
-            this.txtHostPort.Size = new System.Drawing.Size(124, 22);
+            this.txtHostPort.Size = new System.Drawing.Size(126, 22);
             this.txtHostPort.TabIndex = 2;
             this.txtHostPort.Text = "27886";
             // 
             // lblDelay
             // 
             this.lblDelay.AutoSize = true;
-            this.lblDelay.Location = new System.Drawing.Point(44, 129);
+            this.lblDelay.Location = new System.Drawing.Point(44, 121);
             this.lblDelay.Name = "lblDelay";
             this.lblDelay.Size = new System.Drawing.Size(44, 17);
             this.lblDelay.TabIndex = 42;
@@ -82,16 +84,16 @@
             // 
             // txtGuestIP
             // 
-            this.txtGuestIP.Location = new System.Drawing.Point(120, 96);
+            this.txtGuestIP.Location = new System.Drawing.Point(120, 92);
             this.txtGuestIP.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtGuestIP.Name = "txtGuestIP";
-            this.txtGuestIP.Size = new System.Drawing.Size(124, 22);
+            this.txtGuestIP.Size = new System.Drawing.Size(126, 22);
             this.txtGuestIP.TabIndex = 3;
             // 
             // lblHostPort
             // 
             this.lblHostPort.AutoSize = true;
-            this.lblHostPort.Location = new System.Drawing.Point(44, 71);
+            this.lblHostPort.Location = new System.Drawing.Point(44, 69);
             this.lblHostPort.Name = "lblHostPort";
             this.lblHostPort.Size = new System.Drawing.Size(67, 17);
             this.lblHostPort.TabIndex = 39;
@@ -100,7 +102,8 @@
             // lblGuestIP
             // 
             this.lblGuestIP.AutoSize = true;
-            this.lblGuestIP.Location = new System.Drawing.Point(44, 101);
+            this.lblGuestIP.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.lblGuestIP.Location = new System.Drawing.Point(44, 95);
             this.lblGuestIP.Name = "lblGuestIP";
             this.lblGuestIP.Size = new System.Drawing.Size(62, 17);
             this.lblGuestIP.TabIndex = 41;
@@ -108,7 +111,7 @@
             // 
             // numDelay
             // 
-            this.numDelay.Location = new System.Drawing.Point(120, 125);
+            this.numDelay.Location = new System.Drawing.Point(120, 118);
             this.numDelay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.numDelay.Name = "numDelay";
             this.numDelay.Size = new System.Drawing.Size(44, 22);
@@ -125,9 +128,9 @@
             this.txtHostIP.Location = new System.Drawing.Point(120, 40);
             this.txtHostIP.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtHostIP.Name = "txtHostIP";
-            this.txtHostIP.Size = new System.Drawing.Size(124, 22);
+            this.txtHostIP.Size = new System.Drawing.Size(126, 22);
             this.txtHostIP.TabIndex = 1;
-            this.txtHostIP.Text = "0.0.0.0";
+            this.txtHostIP.Text = "127.0.0.1";
             // 
             // lblHostIP
             // 
@@ -140,7 +143,7 @@
             // 
             // btnGenHostCode
             // 
-            this.btnGenHostCode.Location = new System.Drawing.Point(10, 158);
+            this.btnGenHostCode.Location = new System.Drawing.Point(10, 182);
             this.btnGenHostCode.Name = "btnGenHostCode";
             this.btnGenHostCode.Size = new System.Drawing.Size(273, 23);
             this.btnGenHostCode.TabIndex = 6;
@@ -154,7 +157,7 @@
             this.grpCodeLaunch.Controls.Add(this.btnLaunchGame);
             this.grpCodeLaunch.Controls.Add(this.btnCopy);
             this.grpCodeLaunch.Controls.Add(this.txtHostCode);
-            this.grpCodeLaunch.Location = new System.Drawing.Point(5, 187);
+            this.grpCodeLaunch.Location = new System.Drawing.Point(3, 211);
             this.grpCodeLaunch.Name = "grpCodeLaunch";
             this.grpCodeLaunch.Size = new System.Drawing.Size(280, 104);
             this.grpCodeLaunch.TabIndex = 50;
@@ -209,12 +212,11 @@
             this.cboPresetName.TabIndex = 1;
             this.cboPresetName.SelectedIndexChanged += new System.EventHandler(this.cboPresetName_SelectedIndexChanged);
             this.cboPresetName.GotFocus += new System.EventHandler(this.cboPresetName_GotFocus);
-
             // 
             // btnDeletePreset
             // 
             this.btnDeletePreset.Image = ((System.Drawing.Image)(resources.GetObject("btnDeletePreset.Image")));
-            this.btnDeletePreset.Location = new System.Drawing.Point(184, 4);
+            this.btnDeletePreset.Location = new System.Drawing.Point(188, 4);
             this.btnDeletePreset.Name = "btnDeletePreset";
             this.btnDeletePreset.Size = new System.Drawing.Size(30, 27);
             this.btnDeletePreset.TabIndex = 2;
@@ -224,17 +226,36 @@
             // btnSavePreset
             // 
             this.btnSavePreset.Image = ((System.Drawing.Image)(resources.GetObject("btnSavePreset.Image")));
-            this.btnSavePreset.Location = new System.Drawing.Point(214, 4);
+            this.btnSavePreset.Location = new System.Drawing.Point(216, 4);
             this.btnSavePreset.Name = "btnSavePreset";
             this.btnSavePreset.Size = new System.Drawing.Size(30, 27);
             this.btnSavePreset.TabIndex = 3;
             this.btnSavePreset.UseVisualStyleBackColor = true;
             this.btnSavePreset.Click += new System.EventHandler(this.btnSavePreset_Click);
             // 
+            // cboMethod
+            // 
+            this.cboMethod.FormattingEnabled = true;
+            this.cboMethod.Location = new System.Drawing.Point(120, 144);
+            this.cboMethod.Name = "cboMethod";
+            this.cboMethod.Size = new System.Drawing.Size(126, 24);
+            this.cboMethod.TabIndex = 57;
+            // 
+            // lblMethod
+            // 
+            this.lblMethod.AutoSize = true;
+            this.lblMethod.Location = new System.Drawing.Point(44, 147);
+            this.lblMethod.Name = "lblMethod";
+            this.lblMethod.Size = new System.Drawing.Size(55, 17);
+            this.lblMethod.TabIndex = 56;
+            this.lblMethod.Text = "Method";
+            // 
             // HostControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.cboMethod);
+            this.Controls.Add(this.lblMethod);
             this.Controls.Add(this.btnSavePreset);
             this.Controls.Add(this.btnDeletePreset);
             this.Controls.Add(this.cboPresetName);
@@ -250,7 +271,8 @@
             this.Controls.Add(this.lblGuestIP);
             this.Controls.Add(this.numDelay);
             this.Name = "HostControl";
-            this.Size = new System.Drawing.Size(290, 297);
+            this.Size = new System.Drawing.Size(290, 318);
+            this.Load += new System.EventHandler(this.HostControl_Load);
             ((System.ComponentModel.ISupportInitialize)(this.numDelay)).EndInit();
             this.grpCodeLaunch.ResumeLayout(false);
             this.grpCodeLaunch.PerformLayout();
@@ -279,5 +301,7 @@
         private System.Windows.Forms.ComboBox cboPresetName;
         private System.Windows.Forms.Button btnDeletePreset;
         private System.Windows.Forms.Button btnSavePreset;
+        private System.Windows.Forms.ComboBox cboMethod;
+        private System.Windows.Forms.Label lblMethod;
     }
 }

--- a/nullDCNetplayLauncher/HostControl.cs
+++ b/nullDCNetplayLauncher/HostControl.cs
@@ -26,6 +26,13 @@ namespace nullDCNetplayLauncher
             btnDeletePreset.Enabled = presets.ConnectionPresets.Count > 1;
         }
 
+        private void HostControl_Load(object sender, EventArgs e)
+        {
+            cboMethod.DataSource = new BindingSource(Launcher.MethodOptions, null);
+            cboMethod.DisplayMember = "Key";
+            cboMethod.ValueMember = "Value";
+        }
+
         public void SavePreset(string presetName)
         {
             var toEdit = presets.ConnectionPresets.FirstOrDefault(p => p.Name == presetName);
@@ -34,6 +41,7 @@ namespace nullDCNetplayLauncher
                 toEdit.IP = txtHostIP.Text;
                 toEdit.Port = txtHostPort.Text;
                 toEdit.Delay = numDelay.Value;
+                toEdit.Method = Convert.ToInt32(cboMethod.SelectedValue);
             }
             else
             {
@@ -42,6 +50,7 @@ namespace nullDCNetplayLauncher
                 toAdd.IP = txtHostIP.Text;
                 toAdd.Port = txtHostPort.Text;
                 toAdd.Delay = numDelay.Value;
+                toAdd.Method = Convert.ToInt32(cboMethod.SelectedValue);
                 presets.ConnectionPresets.Add(toAdd);
             }
 
@@ -92,6 +101,7 @@ namespace nullDCNetplayLauncher
                 txtHostIP.Text = toLoad.IP;
                 txtHostPort.Text = toLoad.Port;
                 numDelay.Value = toLoad.Delay;
+                cboMethod.SelectedValue = toLoad.Method;
             }
         }
 
@@ -114,7 +124,8 @@ namespace nullDCNetplayLauncher
         {
             var hostCode = Launcher.GenerateHostCode(txtHostIP.Text,
                                                      txtHostPort.Text,
-                                                     Convert.ToInt32(numDelay.Value).ToString());
+                                                     Convert.ToInt32(numDelay.Value).ToString(),
+                                                     Convert.ToInt32(cboMethod.SelectedValue).ToString());
             txtHostCode.Text = hostCode;
         }
 
@@ -126,7 +137,8 @@ namespace nullDCNetplayLauncher
                 hostAddress: txtHostIP.Text,
                 hostPort: txtHostPort.Text,
                 frameDelay: Convert.ToInt32(numDelay.Value)
-                                   .ToString());
+                                   .ToString(),
+                frameMethod: cboMethod.SelectedValue.ToString());
             Launcher.LaunchNullDC(Launcher.SelectedGame, isHost: true);
         }
 
@@ -184,6 +196,7 @@ namespace nullDCNetplayLauncher
             txtHostIP.BackColor = Color.White;
             txtHostPort.BackColor = Color.White;
             numDelay.BackColor = Color.White;
+            cboMethod.BackColor = Color.White;
             LoadPreset(cboPresetName.Text);
         }
     }

--- a/nullDCNetplayLauncher/JoinControl.Designer.cs
+++ b/nullDCNetplayLauncher/JoinControl.Designer.cs
@@ -32,9 +32,7 @@
             this.btnGuess = new System.Windows.Forms.Button();
             this.txtHostPort = new System.Windows.Forms.TextBox();
             this.lblDelay = new System.Windows.Forms.Label();
-            this.txtGuestIP = new System.Windows.Forms.TextBox();
             this.lblHostPort = new System.Windows.Forms.Label();
-            this.lblGuestIP = new System.Windows.Forms.Label();
             this.numDelay = new System.Windows.Forms.NumericUpDown();
             this.txtHostIP = new System.Windows.Forms.TextBox();
             this.lblHostIP = new System.Windows.Forms.Label();
@@ -46,13 +44,15 @@
             this.btnSavePreset = new System.Windows.Forms.Button();
             this.btnDeletePreset = new System.Windows.Forms.Button();
             this.cboPresetName = new System.Windows.Forms.ComboBox();
+            this.lblMethod = new System.Windows.Forms.Label();
+            this.cboMethod = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.numDelay)).BeginInit();
             this.grpCodeLaunch.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnGuess
             // 
-            this.btnGuess.Location = new System.Drawing.Point(171, 233);
+            this.btnGuess.Location = new System.Drawing.Point(169, 204);
             this.btnGuess.Margin = new System.Windows.Forms.Padding(4);
             this.btnGuess.Name = "btnGuess";
             this.btnGuess.Size = new System.Drawing.Size(75, 25);
@@ -72,19 +72,11 @@
             // lblDelay
             // 
             this.lblDelay.AutoSize = true;
-            this.lblDelay.Location = new System.Drawing.Point(44, 237);
+            this.lblDelay.Location = new System.Drawing.Point(44, 207);
             this.lblDelay.Name = "lblDelay";
             this.lblDelay.Size = new System.Drawing.Size(44, 17);
             this.lblDelay.TabIndex = 42;
             this.lblDelay.Text = "Delay";
-            // 
-            // txtGuestIP
-            // 
-            this.txtGuestIP.Location = new System.Drawing.Point(120, 204);
-            this.txtGuestIP.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.txtGuestIP.Name = "txtGuestIP";
-            this.txtGuestIP.Size = new System.Drawing.Size(124, 22);
-            this.txtGuestIP.TabIndex = 3;
             // 
             // lblHostPort
             // 
@@ -95,18 +87,9 @@
             this.lblHostPort.TabIndex = 39;
             this.lblHostPort.Text = "Host Port";
             // 
-            // lblGuestIP
-            // 
-            this.lblGuestIP.AutoSize = true;
-            this.lblGuestIP.Location = new System.Drawing.Point(44, 209);
-            this.lblGuestIP.Name = "lblGuestIP";
-            this.lblGuestIP.Size = new System.Drawing.Size(62, 17);
-            this.lblGuestIP.TabIndex = 41;
-            this.lblGuestIP.Text = "Guest IP";
-            // 
             // numDelay
             // 
-            this.numDelay.Location = new System.Drawing.Point(120, 233);
+            this.numDelay.Location = new System.Drawing.Point(120, 204);
             this.numDelay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.numDelay.Name = "numDelay";
             this.numDelay.Size = new System.Drawing.Size(44, 22);
@@ -217,10 +200,29 @@
             this.cboPresetName.SelectedIndexChanged += new System.EventHandler(this.cboPresetName_SelectedIndexChanged);
             this.cboPresetName.TextChanged += new System.EventHandler(this.cboPresetName_TextChanged);
             // 
+            // lblMethod
+            // 
+            this.lblMethod.AutoSize = true;
+            this.lblMethod.Location = new System.Drawing.Point(44, 235);
+            this.lblMethod.Name = "lblMethod";
+            this.lblMethod.Size = new System.Drawing.Size(55, 17);
+            this.lblMethod.TabIndex = 54;
+            this.lblMethod.Text = "Method";
+            // 
+            // cboMethod
+            // 
+            this.cboMethod.FormattingEnabled = true;
+            this.cboMethod.Location = new System.Drawing.Point(120, 232);
+            this.cboMethod.Name = "cboMethod";
+            this.cboMethod.Size = new System.Drawing.Size(124, 24);
+            this.cboMethod.TabIndex = 55;
+            // 
             // JoinControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.cboMethod);
+            this.Controls.Add(this.lblMethod);
             this.Controls.Add(this.btnSavePreset);
             this.Controls.Add(this.btnDeletePreset);
             this.Controls.Add(this.cboPresetName);
@@ -230,12 +232,11 @@
             this.Controls.Add(this.btnGuess);
             this.Controls.Add(this.txtHostPort);
             this.Controls.Add(this.lblDelay);
-            this.Controls.Add(this.txtGuestIP);
             this.Controls.Add(this.lblHostPort);
-            this.Controls.Add(this.lblGuestIP);
             this.Controls.Add(this.numDelay);
             this.Name = "JoinControl";
             this.Size = new System.Drawing.Size(290, 275);
+            this.Load += new System.EventHandler(this.JoinControl_Load);
             ((System.ComponentModel.ISupportInitialize)(this.numDelay)).EndInit();
             this.grpCodeLaunch.ResumeLayout(false);
             this.grpCodeLaunch.PerformLayout();
@@ -249,9 +250,7 @@
         private System.Windows.Forms.Button btnGuess;
         private System.Windows.Forms.TextBox txtHostPort;
         private System.Windows.Forms.Label lblDelay;
-        private System.Windows.Forms.TextBox txtGuestIP;
         private System.Windows.Forms.Label lblHostPort;
-        private System.Windows.Forms.Label lblGuestIP;
         private System.Windows.Forms.NumericUpDown numDelay;
         private System.Windows.Forms.TextBox txtHostIP;
         private System.Windows.Forms.Label lblHostIP;
@@ -263,5 +262,7 @@
         private System.Windows.Forms.Button btnSavePreset;
         private System.Windows.Forms.Button btnDeletePreset;
         private System.Windows.Forms.ComboBox cboPresetName;
+        private System.Windows.Forms.Label lblMethod;
+        private System.Windows.Forms.ComboBox cboMethod;
     }
 }

--- a/nullDCNetplayLauncher/JoinControl.cs
+++ b/nullDCNetplayLauncher/JoinControl.cs
@@ -26,9 +26,16 @@ namespace nullDCNetplayLauncher
             btnDeletePreset.Enabled = presets.ConnectionPresets.Count > 1;
         }
 
+        private void JoinControl_Load(object sender, EventArgs e)
+        {
+            cboMethod.DataSource = new BindingSource(Launcher.MethodOptions, null);
+            cboMethod.DisplayMember = "Key";
+            cboMethod.ValueMember = "Value";
+        }
+
         private void btnGuess_Click(object sender, EventArgs e)
         {
-            long guessedDelay = Launcher.GuessDelay(txtGuestIP.Text);
+            long guessedDelay = Launcher.GuessDelay(txtHostIP.Text);
             if (guessedDelay >= 0)
             {
                 numDelay.BackColor = Color.White;
@@ -94,10 +101,13 @@ namespace nullDCNetplayLauncher
                     txtHostIP.BackColor = Color.LemonChiffon;
                     txtHostPort.BackColor = Color.LemonChiffon;
                     numDelay.BackColor = Color.LemonChiffon;
+                    cboMethod.BackColor = Color.LemonChiffon;
 
                     txtHostIP.Text = hostInfo.IP;
                     txtHostPort.Text = hostInfo.Port;
                     numDelay.Value = Convert.ToInt32(hostInfo.Delay);
+
+                    cboMethod.SelectedValue = Convert.ToInt32(hostInfo.Method);
                 }
             }
         }
@@ -110,6 +120,7 @@ namespace nullDCNetplayLauncher
                 toEdit.IP = txtHostIP.Text;
                 toEdit.Port = txtHostPort.Text;
                 toEdit.Delay = numDelay.Value;
+                toEdit.Method = Convert.ToInt32(cboMethod.SelectedValue);
             }
             else
             {
@@ -118,6 +129,7 @@ namespace nullDCNetplayLauncher
                 toAdd.IP = txtHostIP.Text;
                 toAdd.Port = txtHostPort.Text;
                 toAdd.Delay = numDelay.Value;
+                toAdd.Method = Convert.ToInt32(cboMethod.SelectedValue);
                 presets.ConnectionPresets.Add(toAdd);
             }
 
@@ -168,6 +180,7 @@ namespace nullDCNetplayLauncher
                 txtHostIP.Text = toLoad.IP;
                 txtHostPort.Text = toLoad.Port;
                 numDelay.Value = toLoad.Delay;
+                cboMethod.SelectedValue = toLoad.Method;
             }
         }
 

--- a/nullDCNetplayLauncher/NetplayLaunchForm.cs
+++ b/nullDCNetplayLauncher/NetplayLaunchForm.cs
@@ -27,7 +27,7 @@ namespace nullDCNetplayLauncher
             {
                 launcherCfgText = File.ReadAllText(Launcher.rootDir + "nullDCNetplayLauncher\\launcher.cfg");
             }
-            catch(System.IO.DirectoryNotFoundException e)
+            catch(System.IO.DirectoryNotFoundException)
             {
                 MessageBox.Show("launcher.cfg not found. Please enter a valid root directory.");
                 System.Environment.Exit(1);

--- a/nullDCNetplayLauncher/SettingsControl.Designer.cs
+++ b/nullDCNetplayLauncher/SettingsControl.Designer.cs
@@ -41,26 +41,35 @@
             this.txtWindowX = new System.Windows.Forms.TextBox();
             this.txtWindowY = new System.Windows.Forms.TextBox();
             this.btnGrabWindowSize = new System.Windows.Forms.Button();
-            this.btnLaunchAntiMicro = new System.Windows.Forms.Button();
             this.btnEditCFG = new System.Windows.Forms.Button();
-            this.btnOpenQKO = new System.Windows.Forms.Button();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabInput = new System.Windows.Forms.TabPage();
             this.btnSaveInput = new System.Windows.Forms.Button();
             this.tabWindow = new System.Windows.Forms.TabPage();
             this.btnSaveWindow = new System.Windows.Forms.Button();
             this.tabAdvanced = new System.Windows.Forms.TabPage();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.numHostFPS = new System.Windows.Forms.NumericUpDown();
+            this.numGuestFPS = new System.Windows.Forms.NumericUpDown();
+            this.btnSaveFPS = new System.Windows.Forms.Button();
             this.btnJoyCpl = new System.Windows.Forms.Button();
+            this.btnOpenQKO = new System.Windows.Forms.Button();
+            this.grpShortcuts = new System.Windows.Forms.GroupBox();
+            this.btnLaunchAntiMicro = new System.Windows.Forms.Button();
             this.tabControl1.SuspendLayout();
             this.tabInput.SuspendLayout();
             this.tabWindow.SuspendLayout();
             this.tabAdvanced.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numHostFPS)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numGuestFPS)).BeginInit();
+            this.grpShortcuts.SuspendLayout();
             this.SuspendLayout();
             // 
             // chkEnableMapper
             // 
             this.chkEnableMapper.AutoSize = true;
-            this.chkEnableMapper.Location = new System.Drawing.Point(6, 6);
+            this.chkEnableMapper.Location = new System.Drawing.Point(9, 6);
             this.chkEnableMapper.Name = "chkEnableMapper";
             this.chkEnableMapper.Size = new System.Drawing.Size(192, 21);
             this.chkEnableMapper.TabIndex = 4;
@@ -71,7 +80,7 @@
             // lblPlayer1
             // 
             this.lblPlayer1.AutoSize = true;
-            this.lblPlayer1.Location = new System.Drawing.Point(6, 38);
+            this.lblPlayer1.Location = new System.Drawing.Point(6, 39);
             this.lblPlayer1.Name = "lblPlayer1";
             this.lblPlayer1.Size = new System.Drawing.Size(60, 17);
             this.lblPlayer1.TabIndex = 5;
@@ -80,7 +89,7 @@
             // lblBackup
             // 
             this.lblBackup.AutoSize = true;
-            this.lblBackup.Location = new System.Drawing.Point(6, 67);
+            this.lblBackup.Location = new System.Drawing.Point(6, 68);
             this.lblBackup.Name = "lblBackup";
             this.lblBackup.Size = new System.Drawing.Size(55, 17);
             this.lblBackup.TabIndex = 6;
@@ -89,7 +98,7 @@
             // lblPlayer2
             // 
             this.lblPlayer2.AutoSize = true;
-            this.lblPlayer2.Location = new System.Drawing.Point(6, 98);
+            this.lblPlayer2.Location = new System.Drawing.Point(6, 99);
             this.lblPlayer2.Name = "lblPlayer2";
             this.lblPlayer2.Size = new System.Drawing.Size(60, 17);
             this.lblPlayer2.TabIndex = 7;
@@ -103,7 +112,7 @@
             "Keyboard",
             "Joystick 1",
             "Joystick 2"});
-            this.cboPlayer1.Location = new System.Drawing.Point(73, 35);
+            this.cboPlayer1.Location = new System.Drawing.Point(73, 36);
             this.cboPlayer1.Name = "cboPlayer1";
             this.cboPlayer1.Size = new System.Drawing.Size(121, 24);
             this.cboPlayer1.TabIndex = 8;
@@ -116,7 +125,7 @@
             "Keyboard",
             "Joystick 1",
             "Joystick 2"});
-            this.cboBackup.Location = new System.Drawing.Point(73, 64);
+            this.cboBackup.Location = new System.Drawing.Point(73, 65);
             this.cboBackup.Name = "cboBackup";
             this.cboBackup.Size = new System.Drawing.Size(121, 24);
             this.cboBackup.TabIndex = 9;
@@ -129,7 +138,7 @@
             "Keyboard",
             "Joystick 1",
             "Joystick 2"});
-            this.cboPlayer2.Location = new System.Drawing.Point(73, 95);
+            this.cboPlayer2.Location = new System.Drawing.Point(73, 96);
             this.cboPlayer2.Name = "cboPlayer2";
             this.cboPlayer2.Size = new System.Drawing.Size(121, 24);
             this.cboPlayer2.TabIndex = 10;
@@ -193,35 +202,15 @@
             this.btnGrabWindowSize.UseVisualStyleBackColor = true;
             this.btnGrabWindowSize.Click += new System.EventHandler(this.btnGrabWindowSize_Click);
             // 
-            // btnLaunchAntiMicro
-            // 
-            this.btnLaunchAntiMicro.Location = new System.Drawing.Point(3, 114);
-            this.btnLaunchAntiMicro.Name = "btnLaunchAntiMicro";
-            this.btnLaunchAntiMicro.Size = new System.Drawing.Size(190, 30);
-            this.btnLaunchAntiMicro.TabIndex = 7;
-            this.btnLaunchAntiMicro.Text = "Launch AntiMicro";
-            this.btnLaunchAntiMicro.UseVisualStyleBackColor = true;
-            this.btnLaunchAntiMicro.Click += new System.EventHandler(this.btnLaunchAntiMicro_Click);
-            // 
             // btnEditCFG
             // 
-            this.btnEditCFG.Location = new System.Drawing.Point(3, 6);
+            this.btnEditCFG.Location = new System.Drawing.Point(9, 48);
             this.btnEditCFG.Name = "btnEditCFG";
-            this.btnEditCFG.Size = new System.Drawing.Size(190, 30);
+            this.btnEditCFG.Size = new System.Drawing.Size(190, 25);
             this.btnEditCFG.TabIndex = 4;
             this.btnEditCFG.Text = "Edit nullDC.cfg";
             this.btnEditCFG.UseVisualStyleBackColor = true;
             this.btnEditCFG.Click += new System.EventHandler(this.btnEditCFG_Click);
-            // 
-            // btnOpenQKO
-            // 
-            this.btnOpenQKO.Location = new System.Drawing.Point(3, 42);
-            this.btnOpenQKO.Name = "btnOpenQKO";
-            this.btnOpenQKO.Size = new System.Drawing.Size(190, 30);
-            this.btnOpenQKO.TabIndex = 5;
-            this.btnOpenQKO.Text = "Open qkoJAMMA Folder";
-            this.btnOpenQKO.UseVisualStyleBackColor = true;
-            this.btnOpenQKO.Click += new System.EventHandler(this.btnOpenQKO_Click);
             // 
             // tabControl1
             // 
@@ -231,7 +220,7 @@
             this.tabControl1.Location = new System.Drawing.Point(4, 4);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(215, 192);
+            this.tabControl1.Size = new System.Drawing.Size(215, 272);
             this.tabControl1.TabIndex = 11;
             // 
             // tabInput
@@ -247,14 +236,14 @@
             this.tabInput.Location = new System.Drawing.Point(4, 25);
             this.tabInput.Name = "tabInput";
             this.tabInput.Padding = new System.Windows.Forms.Padding(3);
-            this.tabInput.Size = new System.Drawing.Size(207, 163);
+            this.tabInput.Size = new System.Drawing.Size(207, 243);
             this.tabInput.TabIndex = 0;
             this.tabInput.Text = "Input";
             this.tabInput.UseVisualStyleBackColor = true;
             // 
             // btnSaveInput
             // 
-            this.btnSaveInput.Location = new System.Drawing.Point(6, 134);
+            this.btnSaveInput.Location = new System.Drawing.Point(9, 214);
             this.btnSaveInput.Name = "btnSaveInput";
             this.btnSaveInput.Size = new System.Drawing.Size(188, 23);
             this.btnSaveInput.TabIndex = 11;
@@ -274,14 +263,14 @@
             this.tabWindow.Location = new System.Drawing.Point(4, 25);
             this.tabWindow.Name = "tabWindow";
             this.tabWindow.Padding = new System.Windows.Forms.Padding(3);
-            this.tabWindow.Size = new System.Drawing.Size(207, 199);
+            this.tabWindow.Size = new System.Drawing.Size(207, 243);
             this.tabWindow.TabIndex = 1;
             this.tabWindow.Text = "Window";
             this.tabWindow.UseVisualStyleBackColor = true;
             // 
             // btnSaveWindow
             // 
-            this.btnSaveWindow.Location = new System.Drawing.Point(6, 134);
+            this.btnSaveWindow.Location = new System.Drawing.Point(9, 214);
             this.btnSaveWindow.Name = "btnSaveWindow";
             this.btnSaveWindow.Size = new System.Drawing.Size(188, 23);
             this.btnSaveWindow.TabIndex = 6;
@@ -291,27 +280,103 @@
             // 
             // tabAdvanced
             // 
-            this.tabAdvanced.Controls.Add(this.btnJoyCpl);
-            this.tabAdvanced.Controls.Add(this.btnOpenQKO);
-            this.tabAdvanced.Controls.Add(this.btnLaunchAntiMicro);
-            this.tabAdvanced.Controls.Add(this.btnEditCFG);
+            this.tabAdvanced.Controls.Add(this.grpShortcuts);
+            this.tabAdvanced.Controls.Add(this.btnSaveFPS);
+            this.tabAdvanced.Controls.Add(this.numGuestFPS);
+            this.tabAdvanced.Controls.Add(this.numHostFPS);
+            this.tabAdvanced.Controls.Add(this.label2);
+            this.tabAdvanced.Controls.Add(this.label1);
             this.tabAdvanced.Location = new System.Drawing.Point(4, 25);
             this.tabAdvanced.Name = "tabAdvanced";
             this.tabAdvanced.Padding = new System.Windows.Forms.Padding(3);
-            this.tabAdvanced.Size = new System.Drawing.Size(207, 163);
+            this.tabAdvanced.Size = new System.Drawing.Size(207, 243);
             this.tabAdvanced.TabIndex = 2;
             this.tabAdvanced.Text = "Advanced";
             this.tabAdvanced.UseVisualStyleBackColor = true;
             // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(15, 10);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(100, 17);
+            this.label1.TabIndex = 7;
+            this.label1.Text = "Host FPS Limit";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(15, 38);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(109, 17);
+            this.label2.TabIndex = 8;
+            this.label2.Text = "Guest FPS Limit";
+            // 
+            // numHostFPS
+            // 
+            this.numHostFPS.Location = new System.Drawing.Point(144, 8);
+            this.numHostFPS.Name = "numHostFPS";
+            this.numHostFPS.Size = new System.Drawing.Size(47, 22);
+            this.numHostFPS.TabIndex = 9;
+            // 
+            // numGuestFPS
+            // 
+            this.numGuestFPS.Location = new System.Drawing.Point(144, 36);
+            this.numGuestFPS.Name = "numGuestFPS";
+            this.numGuestFPS.Size = new System.Drawing.Size(47, 22);
+            this.numGuestFPS.TabIndex = 10;
+            // 
+            // btnSaveFPS
+            // 
+            this.btnSaveFPS.Location = new System.Drawing.Point(18, 64);
+            this.btnSaveFPS.Name = "btnSaveFPS";
+            this.btnSaveFPS.Size = new System.Drawing.Size(173, 23);
+            this.btnSaveFPS.TabIndex = 11;
+            this.btnSaveFPS.Text = "Save FPS Limits";
+            this.btnSaveFPS.UseVisualStyleBackColor = true;
+            this.btnSaveFPS.Click += new System.EventHandler(this.btnSaveFPS_Click);
+            // 
             // btnJoyCpl
             // 
-            this.btnJoyCpl.Location = new System.Drawing.Point(3, 78);
+            this.btnJoyCpl.Location = new System.Drawing.Point(9, 102);
             this.btnJoyCpl.Name = "btnJoyCpl";
-            this.btnJoyCpl.Size = new System.Drawing.Size(190, 30);
+            this.btnJoyCpl.Size = new System.Drawing.Size(190, 25);
             this.btnJoyCpl.TabIndex = 6;
             this.btnJoyCpl.Text = "Windows Game Controllers";
             this.btnJoyCpl.UseVisualStyleBackColor = true;
             this.btnJoyCpl.Click += new System.EventHandler(this.btnJoyCpl_Click);
+            // 
+            // btnOpenQKO
+            // 
+            this.btnOpenQKO.Location = new System.Drawing.Point(9, 75);
+            this.btnOpenQKO.Name = "btnOpenQKO";
+            this.btnOpenQKO.Size = new System.Drawing.Size(190, 25);
+            this.btnOpenQKO.TabIndex = 5;
+            this.btnOpenQKO.Text = "Open qkoJAMMA Folder";
+            this.btnOpenQKO.UseVisualStyleBackColor = true;
+            this.btnOpenQKO.Click += new System.EventHandler(this.btnOpenQKO_Click);
+            // 
+            // grpShortcuts
+            // 
+            this.grpShortcuts.Controls.Add(this.btnLaunchAntiMicro);
+            this.grpShortcuts.Controls.Add(this.btnEditCFG);
+            this.grpShortcuts.Controls.Add(this.btnOpenQKO);
+            this.grpShortcuts.Controls.Add(this.btnJoyCpl);
+            this.grpShortcuts.Location = new System.Drawing.Point(3, 105);
+            this.grpShortcuts.Name = "grpShortcuts";
+            this.grpShortcuts.Size = new System.Drawing.Size(200, 135);
+            this.grpShortcuts.TabIndex = 12;
+            this.grpShortcuts.TabStop = false;
+            this.grpShortcuts.Text = "Shortcuts";
+            // 
+            // btnLaunchAntiMicro
+            // 
+            this.btnLaunchAntiMicro.Location = new System.Drawing.Point(9, 21);
+            this.btnLaunchAntiMicro.Name = "btnLaunchAntiMicro";
+            this.btnLaunchAntiMicro.Size = new System.Drawing.Size(190, 25);
+            this.btnLaunchAntiMicro.TabIndex = 8;
+            this.btnLaunchAntiMicro.Text = "Launch AntiMicro";
+            this.btnLaunchAntiMicro.UseVisualStyleBackColor = true;
             // 
             // SettingsControl
             // 
@@ -319,7 +384,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.tabControl1);
             this.Name = "SettingsControl";
-            this.Size = new System.Drawing.Size(212, 201);
+            this.Size = new System.Drawing.Size(222, 279);
             this.Load += new System.EventHandler(this.SettingsForm_Load);
             this.tabControl1.ResumeLayout(false);
             this.tabInput.ResumeLayout(false);
@@ -327,6 +392,10 @@
             this.tabWindow.ResumeLayout(false);
             this.tabWindow.PerformLayout();
             this.tabAdvanced.ResumeLayout(false);
+            this.tabAdvanced.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numHostFPS)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numGuestFPS)).EndInit();
+            this.grpShortcuts.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -345,15 +414,21 @@
         private System.Windows.Forms.RadioButton rdoCustomSize;
         private System.Windows.Forms.RadioButton rdoStartMax;
         private System.Windows.Forms.RadioButton rdoDefault;
-        private System.Windows.Forms.Button btnOpenQKO;
         private System.Windows.Forms.Button btnEditCFG;
-        private System.Windows.Forms.Button btnLaunchAntiMicro;
         private System.Windows.Forms.TabControl tabControl1;
         private System.Windows.Forms.TabPage tabInput;
         private System.Windows.Forms.Button btnSaveInput;
         private System.Windows.Forms.TabPage tabWindow;
         private System.Windows.Forms.Button btnSaveWindow;
         private System.Windows.Forms.TabPage tabAdvanced;
+        private System.Windows.Forms.GroupBox grpShortcuts;
+        private System.Windows.Forms.Button btnLaunchAntiMicro;
+        private System.Windows.Forms.Button btnOpenQKO;
         private System.Windows.Forms.Button btnJoyCpl;
+        private System.Windows.Forms.Button btnSaveFPS;
+        private System.Windows.Forms.NumericUpDown numGuestFPS;
+        private System.Windows.Forms.NumericUpDown numHostFPS;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/nullDCNetplayLauncher/SettingsControl.cs
+++ b/nullDCNetplayLauncher/SettingsControl.cs
@@ -89,6 +89,17 @@ namespace nullDCNetplayLauncher
             {
                 chkEnableMapper.Checked = false;
             }
+
+            string launcherCfgPath = Launcher.rootDir + "nullDCNetplayLauncher\\launcher.cfg";
+            var launcherCfgLines = File.ReadAllLines(launcherCfgPath);
+            var host_fps_old = launcherCfgLines.Where(s => s.Contains("host_fps=")).ToList().First();
+            var guest_fps_old = launcherCfgLines.Where(s => s.Contains("guest_fps=")).ToList().First();
+
+            var hostFpsEntry = host_fps_old.Split('=')[1];
+            var guestFpsEntry = guest_fps_old.Split('=')[1];
+
+            numHostFPS.Value = Convert.ToInt32(hostFpsEntry);
+            numGuestFPS.Value = Convert.ToInt32(guestFpsEntry);
         }
 
         private void btnLaunchAntiMicro_Click(object sender, EventArgs e)
@@ -178,5 +189,14 @@ namespace nullDCNetplayLauncher
             txtWindowX.Text = ndcWin.X.ToString();
             txtWindowY.Text = ndcWin.Y.ToString();
         }
+
+        private void btnSaveFPS_Click(object sender, EventArgs e)
+        {
+            Launcher.SaveFpsSettings(Convert.ToInt32(numHostFPS.Value),
+                            Convert.ToInt32(numGuestFPS.Value));
+            MessageBox.Show("FPS Limits Successfully Saved");
+        }
+
+        
     }
 }


### PR DESCRIPTION
![methodswitch](https://user-images.githubusercontent.com/504581/84360018-4d570900-ab7e-11ea-9694-38cea164f22e.gif)

* Allows host to select between Frame Limit & Audio Sync for netplay method.
  * Frame Limit acts as default, and is backwards compatible with all versions before 0.6. Better for local games.
  * Audio Sync can play against 0.6 and other players who select the method. Better for further games.

![fps_settings](https://user-images.githubusercontent.com/504581/84360075-62339c80-ab7e-11ea-9600-0b72f80a1cd8.png)
* Host codes include method, with backwards-compatibility intact with older versions
* Command line options now support method selection, as well as functioning host codes
* FPS limit for Host & Guest configurations may be set in Settings. this is useful for testing or adjusting frame rate as close as possible to an actual 60fps for your machine's configuration.